### PR TITLE
add reports routes and surfline client

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask, request
 from app.api import hello
 from app.api import spots
+from app.api import reports
 
 
 def create_app(config_filename):
@@ -8,6 +9,7 @@ def create_app(config_filename):
     app.config.from_object(config_filename)
     app.register_blueprint(hello.blueprint)
     app.register_blueprint(spots.blueprint)
+    app.register_blueprint(reports.blueprint)
 
     @app.after_request
     def log_response(response):

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -1,0 +1,90 @@
+from app.api.spots import db as spots_db
+from app import surfline
+from flask import Blueprint, request
+from marshmallow_jsonapi import Schema, fields
+from marshmallow import pre_load
+from app.api.utils import ok, cant_process
+
+
+FIELDS_FULL = ['id', 'spotName', 'regionName', 'windDirection', 'height',
+               'windSpeed', 'tide', 'waterTempMin', 'waterTempMax']
+FIELDS_BASIC = ['id', 'spotName', 'height']
+FIELDS_GROUPED = ['basic']
+
+
+# Schemas
+
+class ReportSchema(Schema):
+    id = fields.Int()
+    height = fields.Int()
+    spotName = fields.Str()
+    regionName = fields.Str()
+    windDirection = fields.List(fields.Int())
+    windSpeed = fields.List(fields.Float())
+    tide = fields.Float()
+    waterTempMin = fields.Float()
+    waterTempMax = fields.Float()
+
+    class Meta:
+        type_ = 'reports'
+
+    @pre_load()
+    def before_load(self, data):
+        # TODO: remove the land mines. eg accessing a list
+        # when it might be an object.
+        result = {}
+        result['height'] = data.get('Sort', {}).get('height_max')
+        result['id'] = data.get('Quickspot', {}).get('spotid')
+        result['spotName'] = data.get('Quickspot', {}).get('spotname')
+        result['regionName'] = data.get('Quickspot', {}).get('regionname')
+        result['windDirection'] = data.get('Wind', {}).get('wind_direction')[0]
+        result['windSpeed'] = data.get('Wind', {}).get('wind_speed')[0]
+        result['tide'] = data.get('Tide', {}).get('dataPoints')[0]['height']
+        result['waterTempMin'] = data.get('WaterTemp', {}).get('watertemp_min')
+        result['waterTempMax'] = data.get('WaterTemp', {}).get('watertemp_max')
+        return result
+
+
+def prepare_params(paramss):
+    params = [p for p in paramss.split(',') if len(p)]
+    errs = [p for p in params if p not in FIELDS_FULL + FIELDS_GROUPED]
+    if len(errs):
+        return params, errs
+
+    # schema requires an id at all times.
+    if 'id' not in params:
+        params.append('id')
+
+    return params, None
+
+
+
+# Routes
+blueprint = Blueprint('reports', __name__)
+
+
+@blueprint.route('/reports', methods=['GET'])
+def get_reports():
+
+    #TODO: extract params processing to clean things up.
+    fields = None
+    errs = None
+    if 'fields[reports]' in request.args:
+        fields, errs = prepare_params(request.args['fields[reports]'])
+    if errs:
+        return cant_process([f'field=({field}) is invalid' for field in errs])
+
+    # override the groupings with actual lists of fields if necessary
+    if fields is None:
+        fields = FIELDS_FULL
+    elif 'basic' in fields:
+        fields = FIELDS_BASIC
+
+    spot_ids = [spot.spot_id for spot in spots_db.all()]
+    results = surfline.fetch_spots(spot_ids)
+    parsed = [{'type': 'reports', 'attributes': r.json()} for r in results]
+
+    schema = ReportSchema(many=True, only=fields)
+    data, _ = schema.load({'data': parsed})
+
+    return ok(schema.dump(data).data)

--- a/app/api/spots.py
+++ b/app/api/spots.py
@@ -3,8 +3,9 @@ from copy import deepcopy
 from uuid import uuid4
 from flask import Blueprint, request
 from marshmallow_jsonapi import Schema, fields
-from app.api.utils import not_found, cant_process, conflict, \
-    ok, created, no_content
+from app.api.utils import (
+    not_found, cant_process, conflict,
+    ok, created, no_content)
 
 
 # Models
@@ -28,8 +29,9 @@ class SpotSchema(Schema):
 # in mem database, seeded.
 class Database:
     data = [
-        SpotModel(id=str(uuid4()), spot_id='275', description='C Street'),
-        SpotModel(id=str(uuid4()), spot_id='276', description='Silver Strand')
+        SpotModel(id=str(uuid4()), spot_id='4981', description='Pitas Point'),
+        SpotModel(id=str(uuid4()), spot_id='49737', description='Mondos'),
+        SpotModel(id=str(uuid4()), spot_id='4980', description='Emma Wood')
     ]
 
     def _get_data(self):

--- a/app/api/test/test_reports.py
+++ b/app/api/test/test_reports.py
@@ -1,0 +1,26 @@
+import json
+from app.api.test.utils import ApiTestCase
+
+
+class GetReportsTestCase(ApiTestCase):
+
+    def test_get_reports_full(self):
+        expected_fields = ['spotName', 'regionName',
+            'windDirection', 'height', 'windSpeed', 'tide',
+            'waterTempMin', 'waterTempMax'
+        ]
+        res = self.client.get('/reports')
+        data = json.loads(res.data.decode('utf-8'))
+        self.assertEqual(res.status_code, 200)
+        for result in data['data']:
+            for field in expected_fields:
+                self.assertIn(field, result['attributes'])
+
+    def test_get_reports_basic(self):
+        expected_fields = ['spotName', 'height']
+        res = self.client.get('/reports')
+        data = json.loads(res.data.decode('utf-8'))
+        self.assertEqual(res.status_code, 200)
+        for result in data['data']:
+            for field in expected_fields:
+                self.assertIn(field, result['attributes'])

--- a/app/surfline.py
+++ b/app/surfline.py
@@ -1,0 +1,14 @@
+from multiprocessing import Pool
+from requests import Session
+
+SURFLINE_URI = 'http://api.surfline.com/v1/forecasts'
+
+
+def fetch_spots(spot_ids):
+    pool = Pool(5)
+    uris = [f'{SURFLINE_URI}/{spot_id}' for spot_id in spot_ids]
+    with Session() as session:
+        res = pool.map(session.get, uris)
+        pool.close()
+        pool.join()
+        return res


### PR DESCRIPTION
- add GET `/reports`
- user can specify which fields to include in representation. eg `?fields[reports]=spot_name,windDirection`
- user can specify `?fields[reports]=basic` to get a small subset of the data
- uses the surfline api.  the client is very basic, but at least fetches surf spots concurrently from the surfline api.